### PR TITLE
[spec/interpreter/test] Implement basic tail-call proposal

### DIFF
--- a/document/core/appendix/index-instructions.rst
+++ b/document/core/appendix/index-instructions.rst
@@ -4,14 +4,14 @@
 Index of Instructions
 ---------------------
 
-===================================  ================  ==========================================  ========================================  ===============================================================
-Instruction                          Binary Opcode     Type                                        Validation                                Execution
-===================================  ================  ==========================================  ========================================  ===============================================================
-:math:`\UNREACHABLE`                 :math:`\hex{00}`  :math:`[t_1^\ast] \to [t_2^\ast]`           :ref:`validation <valid-unreachable>`     :ref:`execution <exec-unreachable>`
-:math:`\NOP`                         :math:`\hex{01}`  :math:`[] \to []`                           :ref:`validation <valid-nop>`             :ref:`execution <exec-nop>`
-:math:`\BLOCK~[t^?]`                 :math:`\hex{02}`  :math:`[] \to [t^\ast]`                     :ref:`validation <valid-block>`           :ref:`execution <exec-block>`
-:math:`\LOOP~[t^?]`                  :math:`\hex{03}`  :math:`[] \to [t^\ast]`                     :ref:`validation <valid-loop>`            :ref:`execution <exec-loop>`
-:math:`\IF~[t^?]`                    :math:`\hex{04}`  :math:`[] \to [t^\ast]`                     :ref:`validation <valid-if>`              :ref:`execution <exec-if>`
+===================================  ================  ==========================================  ===============================================  ===============================================================
+Instruction                          Binary Opcode     Type                                        Validation                                       Execution
+===================================  ================  ==========================================  ===============================================  ===============================================================
+:math:`\UNREACHABLE`                 :math:`\hex{00}`  :math:`[t_1^\ast] \to [t_2^\ast]`           :ref:`validation <valid-unreachable>`            :ref:`execution <exec-unreachable>`
+:math:`\NOP`                         :math:`\hex{01}`  :math:`[] \to []`                           :ref:`validation <valid-nop>`                    :ref:`execution <exec-nop>`
+:math:`\BLOCK~[t^?]`                 :math:`\hex{02}`  :math:`[] \to [t^\ast]`                     :ref:`validation <valid-block>`                  :ref:`execution <exec-block>`
+:math:`\LOOP~[t^?]`                  :math:`\hex{03}`  :math:`[] \to [t^\ast]`                     :ref:`validation <valid-loop>`                   :ref:`execution <exec-loop>`
+:math:`\IF~[t^?]`                    :math:`\hex{04}`  :math:`[] \to [t^\ast]`                     :ref:`validation <valid-if>`                     :ref:`execution <exec-if>`
 :math:`\ELSE`                        :math:`\hex{05}`                                                
 (reserved)                           :math:`\hex{06}`                                                  
 (reserved)                           :math:`\hex{07}`                                                  
@@ -19,185 +19,185 @@ Instruction                          Binary Opcode     Type                     
 (reserved)                           :math:`\hex{09}`                                                  
 (reserved)                           :math:`\hex{0A}`                                                  
 :math:`\END`                         :math:`\hex{0B}`                                                  
-:math:`\BR~l`                        :math:`\hex{0C}`  :math:`[t_1^\ast~t^?] \to [t_2^\ast]`       :ref:`validation <valid-br>`              :ref:`execution <exec-br>`
-:math:`\BRIF~l`                      :math:`\hex{0D}`  :math:`[t^?~\I32] \to [t^?]`                :ref:`validation <valid-br_if>`           :ref:`execution <exec-br_if>`
-:math:`\BRTABLE~l^\ast~l`            :math:`\hex{0E}`  :math:`[t_1^\ast~t^?~\I32] \to [t_2^\ast]`  :ref:`validation <valid-br_table>`        :ref:`execution <exec-br_table>`
-:math:`\RETURN`                      :math:`\hex{0F}`  :math:`[t_1^\ast~t^?] \to [t_2^\ast]`       :ref:`validation <valid-return>`          :ref:`execution <exec-return>`
-:math:`\CALL~x`                      :math:`\hex{10}`  :math:`[t_1^\ast] \to [t_2^\ast]`           :ref:`validation <valid-call>`            :ref:`execution <exec-call>`
-:math:`\CALLINDIRECT~x`              :math:`\hex{11}`  :math:`[t_1^\ast~\I32] \to [t_2^\ast]`      :ref:`validation <valid-call_indirect>`   :ref:`execution <exec-call_indirect>`
-(reserved)                           :math:`\hex{12}`                                                  
-(reserved)                           :math:`\hex{13}`                                                  
+:math:`\BR~l`                        :math:`\hex{0C}`  :math:`[t_1^\ast~t^?] \to [t_2^\ast]`       :ref:`validation <valid-br>`                     :ref:`execution <exec-br>`
+:math:`\BRIF~l`                      :math:`\hex{0D}`  :math:`[t^?~\I32] \to [t^?]`                :ref:`validation <valid-br_if>`                  :ref:`execution <exec-br_if>`
+:math:`\BRTABLE~l^\ast~l`            :math:`\hex{0E}`  :math:`[t_1^\ast~t^?~\I32] \to [t_2^\ast]`  :ref:`validation <valid-br_table>`               :ref:`execution <exec-br_table>`
+:math:`\RETURN`                      :math:`\hex{0F}`  :math:`[t_1^\ast~t^?] \to [t_2^\ast]`       :ref:`validation <valid-return>`                 :ref:`execution <exec-return>`
+:math:`\CALL~x`                      :math:`\hex{10}`  :math:`[t_1^\ast] \to [t_2^\ast]`           :ref:`validation <valid-call>`                   :ref:`execution <exec-call>`
+:math:`\CALLINDIRECT~x`              :math:`\hex{11}`  :math:`[t_1^\ast~\I32] \to [t_2^\ast]`      :ref:`validation <valid-call_indirect>`          :ref:`execution <exec-call_indirect>`
+:math:`\RETURNCALL~x`                :math:`\hex{12}`  :math:`[t_1^\ast] \to [t_2^\ast]`           :ref:`validation <valid-return_call>`            :ref:`execution <exec-return_call>`
+:math:`\RETURNCALLINDIRECT~x`        :math:`\hex{12}`  :math:`[t_1^\ast~\I32] \to [t_2^\ast]`      :ref:`validation <valid-return_call_indirect>`   :ref:`execution <exec-return_call_indirect>`
 (reserved)                           :math:`\hex{14}`                                                  
 (reserved)                           :math:`\hex{15}`                                                  
 (reserved)                           :math:`\hex{16}`                                                  
 (reserved)                           :math:`\hex{17}`                                                  
 (reserved)                           :math:`\hex{18}`                                                  
 (reserved)                           :math:`\hex{19}`                                                  
-:math:`\DROP`                        :math:`\hex{1A}`  :math:`[t] \to []`                          :ref:`validation <valid-drop>`            :ref:`execution <exec-drop>`
-:math:`\SELECT`                      :math:`\hex{1B}`  :math:`[t~t~\I32] \to [t]`                  :ref:`validation <valid-select>`          :ref:`execution <exec-select>`
+:math:`\DROP`                        :math:`\hex{1A}`  :math:`[t] \to []`                          :ref:`validation <valid-drop>`                   :ref:`execution <exec-drop>`
+:math:`\SELECT`                      :math:`\hex{1B}`  :math:`[t~t~\I32] \to [t]`                  :ref:`validation <valid-select>`                 :ref:`execution <exec-select>`
 (reserved)                           :math:`\hex{1C}`                                                  
 (reserved)                           :math:`\hex{1D}`                                                  
 (reserved)                           :math:`\hex{1E}`                                                  
 (reserved)                           :math:`\hex{1F}`                                                  
-:math:`\GETLOCAL~x`                  :math:`\hex{20}`  :math:`[] \to [t]`                          :ref:`validation <valid-get_local>`       :ref:`execution <exec-get_local>`
-:math:`\SETLOCAL~x`                  :math:`\hex{21}`  :math:`[t] \to []`                          :ref:`validation <valid-set_local>`       :ref:`execution <exec-set_local>`
-:math:`\TEELOCAL~x`                  :math:`\hex{22}`  :math:`[t] \to [t]`                         :ref:`validation <valid-tee_local>`       :ref:`execution <exec-tee_local>`
-:math:`\GETGLOBAL~x`                 :math:`\hex{23}`  :math:`[] \to [t]`                          :ref:`validation <valid-get_global>`      :ref:`execution <exec-get_global>`
-:math:`\SETGLOBAL~x`                 :math:`\hex{24}`  :math:`[t] \to []`                          :ref:`validation <valid-set_global>`      :ref:`execution <exec-set_global>`
+:math:`\GETLOCAL~x`                  :math:`\hex{20}`  :math:`[] \to [t]`                          :ref:`validation <valid-get_local>`              :ref:`execution <exec-get_local>`
+:math:`\SETLOCAL~x`                  :math:`\hex{21}`  :math:`[t] \to []`                          :ref:`validation <valid-set_local>`              :ref:`execution <exec-set_local>`
+:math:`\TEELOCAL~x`                  :math:`\hex{22}`  :math:`[t] \to [t]`                         :ref:`validation <valid-tee_local>`              :ref:`execution <exec-tee_local>`
+:math:`\GETGLOBAL~x`                 :math:`\hex{23}`  :math:`[] \to [t]`                          :ref:`validation <valid-get_global>`             :ref:`execution <exec-get_global>`
+:math:`\SETGLOBAL~x`                 :math:`\hex{24}`  :math:`[t] \to []`                          :ref:`validation <valid-set_global>`             :ref:`execution <exec-set_global>`
 (reserved)                           :math:`\hex{25}`                                                  
 (reserved)                           :math:`\hex{26}`                                                  
 (reserved)                           :math:`\hex{27}`                                                  
-:math:`\I32.\LOAD~\memarg`           :math:`\hex{28}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-load>`            :ref:`execution <exec-load>`
-:math:`\I64.\LOAD~\memarg`           :math:`\hex{29}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-load>`            :ref:`execution <exec-load>`
-:math:`\F32.\LOAD~\memarg`           :math:`\hex{2A}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-load>`            :ref:`execution <exec-load>`
-:math:`\F64.\LOAD~\memarg`           :math:`\hex{2B}`  :math:`[\I32] \to [\F64]`                   :ref:`validation <valid-load>`            :ref:`execution <exec-load>`
-:math:`\I32.\LOAD\K{8\_s}~\memarg`   :math:`\hex{2C}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I32.\LOAD\K{8\_u}~\memarg`   :math:`\hex{2D}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I32.\LOAD\K{16\_s}~\memarg`  :math:`\hex{2E}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I32.\LOAD\K{16\_u}~\memarg`  :math:`\hex{2F}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I64.\LOAD\K{8\_s}~\memarg`   :math:`\hex{30}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I64.\LOAD\K{8\_u}~\memarg`   :math:`\hex{31}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I64.\LOAD\K{16\_s}~\memarg`  :math:`\hex{32}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I64.\LOAD\K{16\_u}~\memarg`  :math:`\hex{33}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I64.\LOAD\K{32\_s}~\memarg`  :math:`\hex{34}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I64.\LOAD\K{32\_u}~\memarg`  :math:`\hex{35}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`           :ref:`execution <exec-loadn>`
-:math:`\I32.\STORE~\memarg`          :math:`\hex{36}`  :math:`[\I32~\I32] \to []`                  :ref:`validation <valid-store>`           :ref:`execution <exec-store>`
-:math:`\I64.\STORE~\memarg`          :math:`\hex{37}`  :math:`[\I32~\I64] \to []`                  :ref:`validation <valid-store>`           :ref:`execution <exec-store>`
-:math:`\F32.\STORE~\memarg`          :math:`\hex{38}`  :math:`[\I32~\F32] \to []`                  :ref:`validation <valid-store>`           :ref:`execution <exec-store>`
-:math:`\F64.\STORE~\memarg`          :math:`\hex{39}`  :math:`[\I32~\F64] \to []`                  :ref:`validation <valid-store>`           :ref:`execution <exec-store>`
-:math:`\I32.\STORE\K{8}~\memarg`     :math:`\hex{3A}`  :math:`[\I32~\I32] \to []`                  :ref:`validation <valid-storen>`          :ref:`execution <exec-storen>`
-:math:`\I32.\STORE\K{16}~\memarg`    :math:`\hex{3B}`  :math:`[\I32~\I32] \to []`                  :ref:`validation <valid-storen>`          :ref:`execution <exec-storen>`
-:math:`\I64.\STORE\K{8}~\memarg`     :math:`\hex{3C}`  :math:`[\I32~\I64] \to []`                  :ref:`validation <valid-storen>`          :ref:`execution <exec-storen>`
-:math:`\I64.\STORE\K{16}~\memarg`    :math:`\hex{3D}`  :math:`[\I32~\I64] \to []`                  :ref:`validation <valid-storen>`          :ref:`execution <exec-storen>`
-:math:`\I64.\STORE\K{32}~\memarg`    :math:`\hex{3E}`  :math:`[\I32~\I64] \to []`                  :ref:`validation <valid-storen>`          :ref:`execution <exec-storen>`
-:math:`\CURRENTMEMORY`               :math:`\hex{3F}`  :math:`[] \to [\I32]`                       :ref:`validation <valid-current_memory>`  :ref:`execution <exec-current_memory>`
-:math:`\GROWMEMORY`                  :math:`\hex{40}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-grow_memory>`     :ref:`execution <exec-grow_memory>`
-:math:`\I32.\CONST~\i32`             :math:`\hex{41}`  :math:`[] \to [\I32]`                       :ref:`validation <valid-const>`           :ref:`execution <exec-const>`
-:math:`\I64.\CONST~\i64`             :math:`\hex{42}`  :math:`[] \to [\I64]`                       :ref:`validation <valid-const>`           :ref:`execution <exec-const>`
-:math:`\F32.\CONST~\f32`             :math:`\hex{43}`  :math:`[] \to [\F32]`                       :ref:`validation <valid-const>`           :ref:`execution <exec-const>`
-:math:`\F64.\CONST~\f64`             :math:`\hex{44}`  :math:`[] \to [\F64]`                       :ref:`validation <valid-const>`           :ref:`execution <exec-const>`
-:math:`\I32.\EQZ`                    :math:`\hex{45}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-testop>`          :ref:`execution <exec-testop>`, :ref:`operator <op-ieqz>`
-:math:`\I32.\EQ`                     :math:`\hex{46}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ieq>`
-:math:`\I32.\NE`                     :math:`\hex{47}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ine>`
-:math:`\I32.\LT\K{\_s}`              :math:`\hex{48}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ilt_s>`
-:math:`\I32.\LT\K{\_u}`              :math:`\hex{49}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ilt_u>`
-:math:`\I32.\GT\K{\_s}`              :math:`\hex{4A}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-igt_s>`
-:math:`\I32.\GT\K{\_u}`              :math:`\hex{4B}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-igt_u>`
-:math:`\I32.\LE\K{\_s}`              :math:`\hex{4C}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ile_s>`
-:math:`\I32.\LE\K{\_u}`              :math:`\hex{4D}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ile_u>`
-:math:`\I32.\GE\K{\_s}`              :math:`\hex{4E}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ige_s>`
-:math:`\I32.\GE\K{\_u}`              :math:`\hex{4F}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ige_u>`
-:math:`\I64.\EQZ`                    :math:`\hex{50}`  :math:`[\I64] \to [\I32]`                   :ref:`validation <valid-testop>`          :ref:`execution <exec-testop>`, :ref:`operator <op-ieqz>`
-:math:`\I64.\EQ`                     :math:`\hex{51}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ieq>`
-:math:`\I64.\NE`                     :math:`\hex{52}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ine>`
-:math:`\I64.\LT\K{\_s}`              :math:`\hex{53}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ilt_s>`
-:math:`\I64.\LT\K{\_u}`              :math:`\hex{54}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ilt_u>`
-:math:`\I64.\GT\K{\_s}`              :math:`\hex{55}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-igt_s>`
-:math:`\I64.\GT\K{\_u}`              :math:`\hex{56}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-igt_u>`
-:math:`\I64.\LE\K{\_s}`              :math:`\hex{57}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ile_s>`
-:math:`\I64.\LE\K{\_u}`              :math:`\hex{58}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ile_u>`
-:math:`\I64.\GE\K{\_s}`              :math:`\hex{59}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ige_s>`
-:math:`\I64.\GE\K{\_u}`              :math:`\hex{5A}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-ige_u>`
-:math:`\F32.\EQ`                     :math:`\hex{5B}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-feq>`
-:math:`\F32.\NE`                     :math:`\hex{5C}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-fne>`
-:math:`\F32.\LT`                     :math:`\hex{5D}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-flt>`
-:math:`\F32.\GT`                     :math:`\hex{5E}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-fgt>`
-:math:`\F32.\LE`                     :math:`\hex{5F}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-fle>`
-:math:`\F32.\GE`                     :math:`\hex{60}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-fge>`
-:math:`\F64.\EQ`                     :math:`\hex{61}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-feq>`
-:math:`\F64.\NE`                     :math:`\hex{62}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-fne>`
-:math:`\F64.\LT`                     :math:`\hex{63}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-flt>`
-:math:`\F64.\GT`                     :math:`\hex{64}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-fgt>`
-:math:`\F64.\LE`                     :math:`\hex{65}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-fle>`
-:math:`\F64.\GE`                     :math:`\hex{66}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`           :ref:`execution <exec-relop>`, :ref:`operator <op-fge>`
-:math:`\I32.\CLZ`                    :math:`\hex{67}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iclz>`
-:math:`\I32.\CTZ`                    :math:`\hex{68}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-ictz>`
-:math:`\I32.\POPCNT`                 :math:`\hex{69}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-ipopcnt>`
-:math:`\I32.\ADD`                    :math:`\hex{6A}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-iadd>`
-:math:`\I32.\SUB`                    :math:`\hex{6B}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-isub>`
-:math:`\I32.\MUL`                    :math:`\hex{6C}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-imul>`
-:math:`\I32.\DIV\K{\_s}`             :math:`\hex{6D}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-idiv_s>`
-:math:`\I32.\DIV\K{\_u}`             :math:`\hex{6E}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-idiv_u>`
-:math:`\I32.\REM\K{\_s}`             :math:`\hex{6F}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-irem_s>`
-:math:`\I32.\REM\K{\_u}`             :math:`\hex{70}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-irem_u>`
-:math:`\I32.\AND`                    :math:`\hex{71}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-iand>`
-:math:`\I32.\OR`                     :math:`\hex{72}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ior>`
-:math:`\I32.\XOR`                    :math:`\hex{73}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ixor>`
-:math:`\I32.\SHL`                    :math:`\hex{74}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ishl>`
-:math:`\I32.\SHR\K{\_s}`             :math:`\hex{75}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ishr_s>`
-:math:`\I32.\SHR\K{\_u}`             :math:`\hex{76}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ishr_u>`
-:math:`\I32.\ROTL`                   :math:`\hex{77}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-irotl>`
-:math:`\I32.\ROTR`                   :math:`\hex{78}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-irotr>`
-:math:`\I64.\CLZ`                    :math:`\hex{79}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iclz>`
-:math:`\I64.\CTZ`                    :math:`\hex{7A}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-ictz>`
-:math:`\I64.\POPCNT`                 :math:`\hex{7B}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-ipopcnt>`
-:math:`\I64.\ADD`                    :math:`\hex{7C}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-iadd>`
-:math:`\I64.\SUB`                    :math:`\hex{7D}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-isub>`
-:math:`\I64.\MUL`                    :math:`\hex{7E}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-imul>`
-:math:`\I64.\DIV\K{\_s}`             :math:`\hex{7F}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-idiv_s>`
-:math:`\I64.\DIV\K{\_u}`             :math:`\hex{80}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-idiv_u>`
-:math:`\I64.\REM\K{\_s}`             :math:`\hex{81}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-irem_s>`
-:math:`\I64.\REM\K{\_u}`             :math:`\hex{82}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-irem_u>`
-:math:`\I64.\AND`                    :math:`\hex{83}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-iand>`
-:math:`\I64.\OR`                     :math:`\hex{84}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ior>`
-:math:`\I64.\XOR`                    :math:`\hex{85}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ixor>`
-:math:`\I64.\SHL`                    :math:`\hex{86}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ishl>`
-:math:`\I64.\SHR\K{\_s}`             :math:`\hex{87}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ishr_s>`
-:math:`\I64.\SHR\K{\_u}`             :math:`\hex{88}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-ishr_u>`
-:math:`\I64.\ROTL`                   :math:`\hex{89}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-irotl>`
-:math:`\I64.\ROTR`                   :math:`\hex{8A}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-irotr>`
-:math:`\F32.\ABS`                    :math:`\hex{8B}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fabs>`
-:math:`\F32.\NEG`                    :math:`\hex{8C}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fneg>`
-:math:`\F32.\CEIL`                   :math:`\hex{8D}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fceil>`
-:math:`\F32.\FLOOR`                  :math:`\hex{8E}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-ffloor>`
-:math:`\F32.\TRUNC`                  :math:`\hex{8F}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-ftrunc>`
-:math:`\F32.\NEAREST`                :math:`\hex{90}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fnearest>`
-:math:`\F32.\SQRT`                   :math:`\hex{91}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fsqrt>`
-:math:`\F32.\ADD`                    :math:`\hex{92}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fadd>`
-:math:`\F32.\SUB`                    :math:`\hex{93}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fsub>`
-:math:`\F32.\MUL`                    :math:`\hex{94}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fmul>`
-:math:`\F32.\DIV`                    :math:`\hex{95}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fdiv>`
-:math:`\F32.\FMIN`                   :math:`\hex{96}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fmin>`
-:math:`\F32.\FMAX`                   :math:`\hex{97}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fmax>`
-:math:`\F32.\COPYSIGN`               :math:`\hex{98}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fcopysign>`
-:math:`\F64.\ABS`                    :math:`\hex{99}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fabs>`
-:math:`\F64.\NEG`                    :math:`\hex{9A}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fneg>`
-:math:`\F64.\CEIL`                   :math:`\hex{9B}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fceil>`
-:math:`\F64.\FLOOR`                  :math:`\hex{9C}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-ffloor>`
-:math:`\F64.\TRUNC`                  :math:`\hex{9D}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-ftrunc>`
-:math:`\F64.\NEAREST`                :math:`\hex{9E}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fnearest>`
-:math:`\F64.\SQRT`                   :math:`\hex{9F}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-fsqrt>`
-:math:`\F64.\ADD`                    :math:`\hex{A0}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fadd>`
-:math:`\F64.\SUB`                    :math:`\hex{A1}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fsub>`
-:math:`\F64.\MUL`                    :math:`\hex{A2}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fmul>`
-:math:`\F64.\DIV`                    :math:`\hex{A3}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fdiv>`
-:math:`\F64.\FMIN`                   :math:`\hex{A4}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fmin>`
-:math:`\F64.\FMAX`                   :math:`\hex{A5}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fmax>`
-:math:`\F64.\COPYSIGN`               :math:`\hex{A6}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`           :ref:`execution <exec-binop>`, :ref:`operator <op-fcopysign>`
-:math:`\I32.\WRAP\K{/}\I64`          :math:`\hex{A7}`  :math:`[\I64] \to [\I32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-wrap>`
-:math:`\I32.\TRUNC\K{\_s/}\F32`      :math:`\hex{A8}`  :math:`[\F32] \to [\I32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_s>`
-:math:`\I32.\TRUNC\K{\_u/}\F32`      :math:`\hex{A9}`  :math:`[\F32] \to [\I32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_u>`
-:math:`\I32.\TRUNC\K{\_s/}\F64`      :math:`\hex{AA}`  :math:`[\F64] \to [\I32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_s>`
-:math:`\I32.\TRUNC\K{\_u/}\F64`      :math:`\hex{AB}`  :math:`[\F64] \to [\I32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_u>`
-:math:`\I64.\EXTEND\K{\_s/}\I32`     :math:`\hex{AC}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-extend_s>`
-:math:`\I64.\EXTEND\K{\_u/}\I32`     :math:`\hex{AD}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-extend_u>`
-:math:`\I64.\TRUNC\K{\_s/}\F32`      :math:`\hex{AE}`  :math:`[\F32] \to [\I64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_s>`
-:math:`\I64.\TRUNC\K{\_u/}\F32`      :math:`\hex{AF}`  :math:`[\F32] \to [\I64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_u>`
-:math:`\I64.\TRUNC\K{\_s/}\F64`      :math:`\hex{B0}`  :math:`[\F64] \to [\I64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_s>`
-:math:`\I64.\TRUNC\K{\_u/}\F64`      :math:`\hex{B1}`  :math:`[\F64] \to [\I64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_u>`
-:math:`\F32.\CONVERT\K{\_s/}\I32`    :math:`\hex{B2}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_s>`
-:math:`\F32.\CONVERT\K{\_u/}\I32`    :math:`\hex{B3}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_u>`
-:math:`\F32.\CONVERT\K{\_s/}\I64`    :math:`\hex{B4}`  :math:`[\I64] \to [\F32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_s>`
-:math:`\F32.\CONVERT\K{\_u/}\I64`    :math:`\hex{B5}`  :math:`[\I64] \to [\F32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_u>`
-:math:`\F32.\DEMOTE\K{/}\F64`        :math:`\hex{B6}`  :math:`[\F64] \to [\F32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-demote>`
-:math:`\F64.\CONVERT\K{\_s/}\I32`    :math:`\hex{B7}`  :math:`[\I32] \to [\F64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_s>`
-:math:`\F64.\CONVERT\K{\_u/}\I32`    :math:`\hex{B8}`  :math:`[\I32] \to [\F64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_u>`
-:math:`\F64.\CONVERT\K{\_s/}\I64`    :math:`\hex{B9}`  :math:`[\I64] \to [\F64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_s>`
-:math:`\F64.\CONVERT\K{\_u/}\I64`    :math:`\hex{BA}`  :math:`[\I64] \to [\F64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_u>`
-:math:`\F64.\PROMOTE\K{/}\F32`       :math:`\hex{BB}`  :math:`[\F32] \to [\F64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-promote>`
-:math:`\I32.\REINTERPRET\K{/}\F32`   :math:`\hex{BC}`  :math:`[\F32] \to [\I32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
-:math:`\I64.\REINTERPRET\K{/}\F64`   :math:`\hex{BD}`  :math:`[\F64] \to [\I64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
-:math:`\F32.\REINTERPRET\K{/}\I32`   :math:`\hex{BE}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
-:math:`\F64.\REINTERPRET\K{/}\I64`   :math:`\hex{BF}`  :math:`[\I64] \to [\F64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
-===================================  ================  ==========================================  ========================================  ===============================================================
+:math:`\I32.\LOAD~\memarg`           :math:`\hex{28}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-load>`                   :ref:`execution <exec-load>`
+:math:`\I64.\LOAD~\memarg`           :math:`\hex{29}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-load>`                   :ref:`execution <exec-load>`
+:math:`\F32.\LOAD~\memarg`           :math:`\hex{2A}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-load>`                   :ref:`execution <exec-load>`
+:math:`\F64.\LOAD~\memarg`           :math:`\hex{2B}`  :math:`[\I32] \to [\F64]`                   :ref:`validation <valid-load>`                   :ref:`execution <exec-load>`
+:math:`\I32.\LOAD\K{8\_s}~\memarg`   :math:`\hex{2C}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I32.\LOAD\K{8\_u}~\memarg`   :math:`\hex{2D}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I32.\LOAD\K{16\_s}~\memarg`  :math:`\hex{2E}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I32.\LOAD\K{16\_u}~\memarg`  :math:`\hex{2F}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I64.\LOAD\K{8\_s}~\memarg`   :math:`\hex{30}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I64.\LOAD\K{8\_u}~\memarg`   :math:`\hex{31}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I64.\LOAD\K{16\_s}~\memarg`  :math:`\hex{32}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I64.\LOAD\K{16\_u}~\memarg`  :math:`\hex{33}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I64.\LOAD\K{32\_s}~\memarg`  :math:`\hex{34}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I64.\LOAD\K{32\_u}~\memarg`  :math:`\hex{35}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-loadn>`                  :ref:`execution <exec-loadn>`
+:math:`\I32.\STORE~\memarg`          :math:`\hex{36}`  :math:`[\I32~\I32] \to []`                  :ref:`validation <valid-store>`                  :ref:`execution <exec-store>`
+:math:`\I64.\STORE~\memarg`          :math:`\hex{37}`  :math:`[\I32~\I64] \to []`                  :ref:`validation <valid-store>`                  :ref:`execution <exec-store>`
+:math:`\F32.\STORE~\memarg`          :math:`\hex{38}`  :math:`[\I32~\F32] \to []`                  :ref:`validation <valid-store>`                  :ref:`execution <exec-store>`
+:math:`\F64.\STORE~\memarg`          :math:`\hex{39}`  :math:`[\I32~\F64] \to []`                  :ref:`validation <valid-store>`                  :ref:`execution <exec-store>`
+:math:`\I32.\STORE\K{8}~\memarg`     :math:`\hex{3A}`  :math:`[\I32~\I32] \to []`                  :ref:`validation <valid-storen>`                 :ref:`execution <exec-storen>`
+:math:`\I32.\STORE\K{16}~\memarg`    :math:`\hex{3B}`  :math:`[\I32~\I32] \to []`                  :ref:`validation <valid-storen>`                 :ref:`execution <exec-storen>`
+:math:`\I64.\STORE\K{8}~\memarg`     :math:`\hex{3C}`  :math:`[\I32~\I64] \to []`                  :ref:`validation <valid-storen>`                 :ref:`execution <exec-storen>`
+:math:`\I64.\STORE\K{16}~\memarg`    :math:`\hex{3D}`  :math:`[\I32~\I64] \to []`                  :ref:`validation <valid-storen>`                 :ref:`execution <exec-storen>`
+:math:`\I64.\STORE\K{32}~\memarg`    :math:`\hex{3E}`  :math:`[\I32~\I64] \to []`                  :ref:`validation <valid-storen>`                 :ref:`execution <exec-storen>`
+:math:`\CURRENTMEMORY`               :math:`\hex{3F}`  :math:`[] \to [\I32]`                       :ref:`validation <valid-current_memory>`         :ref:`execution <exec-current_memory>`
+:math:`\GROWMEMORY`                  :math:`\hex{40}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-grow_memory>`            :ref:`execution <exec-grow_memory>`
+:math:`\I32.\CONST~\i32`             :math:`\hex{41}`  :math:`[] \to [\I32]`                       :ref:`validation <valid-const>`                  :ref:`execution <exec-const>`
+:math:`\I64.\CONST~\i64`             :math:`\hex{42}`  :math:`[] \to [\I64]`                       :ref:`validation <valid-const>`                  :ref:`execution <exec-const>`
+:math:`\F32.\CONST~\f32`             :math:`\hex{43}`  :math:`[] \to [\F32]`                       :ref:`validation <valid-const>`                  :ref:`execution <exec-const>`
+:math:`\F64.\CONST~\f64`             :math:`\hex{44}`  :math:`[] \to [\F64]`                       :ref:`validation <valid-const>`                  :ref:`execution <exec-const>`
+:math:`\I32.\EQZ`                    :math:`\hex{45}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-testop>`                 :ref:`execution <exec-testop>`, :ref:`operator <op-ieqz>`
+:math:`\I32.\EQ`                     :math:`\hex{46}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ieq>`
+:math:`\I32.\NE`                     :math:`\hex{47}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ine>`
+:math:`\I32.\LT\K{\_s}`              :math:`\hex{48}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ilt_s>`
+:math:`\I32.\LT\K{\_u}`              :math:`\hex{49}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ilt_u>`
+:math:`\I32.\GT\K{\_s}`              :math:`\hex{4A}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-igt_s>`
+:math:`\I32.\GT\K{\_u}`              :math:`\hex{4B}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-igt_u>`
+:math:`\I32.\LE\K{\_s}`              :math:`\hex{4C}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ile_s>`
+:math:`\I32.\LE\K{\_u}`              :math:`\hex{4D}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ile_u>`
+:math:`\I32.\GE\K{\_s}`              :math:`\hex{4E}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ige_s>`
+:math:`\I32.\GE\K{\_u}`              :math:`\hex{4F}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ige_u>`
+:math:`\I64.\EQZ`                    :math:`\hex{50}`  :math:`[\I64] \to [\I32]`                   :ref:`validation <valid-testop>`                 :ref:`execution <exec-testop>`, :ref:`operator <op-ieqz>`
+:math:`\I64.\EQ`                     :math:`\hex{51}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ieq>`
+:math:`\I64.\NE`                     :math:`\hex{52}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ine>`
+:math:`\I64.\LT\K{\_s}`              :math:`\hex{53}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ilt_s>`
+:math:`\I64.\LT\K{\_u}`              :math:`\hex{54}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ilt_u>`
+:math:`\I64.\GT\K{\_s}`              :math:`\hex{55}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-igt_s>`
+:math:`\I64.\GT\K{\_u}`              :math:`\hex{56}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-igt_u>`
+:math:`\I64.\LE\K{\_s}`              :math:`\hex{57}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ile_s>`
+:math:`\I64.\LE\K{\_u}`              :math:`\hex{58}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ile_u>`
+:math:`\I64.\GE\K{\_s}`              :math:`\hex{59}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ige_s>`
+:math:`\I64.\GE\K{\_u}`              :math:`\hex{5A}`  :math:`[\I64~\I64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-ige_u>`
+:math:`\F32.\EQ`                     :math:`\hex{5B}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-feq>`
+:math:`\F32.\NE`                     :math:`\hex{5C}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-fne>`
+:math:`\F32.\LT`                     :math:`\hex{5D}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-flt>`
+:math:`\F32.\GT`                     :math:`\hex{5E}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-fgt>`
+:math:`\F32.\LE`                     :math:`\hex{5F}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-fle>`
+:math:`\F32.\GE`                     :math:`\hex{60}`  :math:`[\F32~\F32] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-fge>`
+:math:`\F64.\EQ`                     :math:`\hex{61}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-feq>`
+:math:`\F64.\NE`                     :math:`\hex{62}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-fne>`
+:math:`\F64.\LT`                     :math:`\hex{63}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-flt>`
+:math:`\F64.\GT`                     :math:`\hex{64}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-fgt>`
+:math:`\F64.\LE`                     :math:`\hex{65}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-fle>`
+:math:`\F64.\GE`                     :math:`\hex{66}`  :math:`[\F64~\F64] \to [\I32]`              :ref:`validation <valid-relop>`                  :ref:`execution <exec-relop>`, :ref:`operator <op-fge>`
+:math:`\I32.\CLZ`                    :math:`\hex{67}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-iclz>`
+:math:`\I32.\CTZ`                    :math:`\hex{68}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-ictz>`
+:math:`\I32.\POPCNT`                 :math:`\hex{69}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-ipopcnt>`
+:math:`\I32.\ADD`                    :math:`\hex{6A}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-iadd>`
+:math:`\I32.\SUB`                    :math:`\hex{6B}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-isub>`
+:math:`\I32.\MUL`                    :math:`\hex{6C}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-imul>`
+:math:`\I32.\DIV\K{\_s}`             :math:`\hex{6D}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-idiv_s>`
+:math:`\I32.\DIV\K{\_u}`             :math:`\hex{6E}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-idiv_u>`
+:math:`\I32.\REM\K{\_s}`             :math:`\hex{6F}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-irem_s>`
+:math:`\I32.\REM\K{\_u}`             :math:`\hex{70}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-irem_u>`
+:math:`\I32.\AND`                    :math:`\hex{71}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-iand>`
+:math:`\I32.\OR`                     :math:`\hex{72}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ior>`
+:math:`\I32.\XOR`                    :math:`\hex{73}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ixor>`
+:math:`\I32.\SHL`                    :math:`\hex{74}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ishl>`
+:math:`\I32.\SHR\K{\_s}`             :math:`\hex{75}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ishr_s>`
+:math:`\I32.\SHR\K{\_u}`             :math:`\hex{76}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ishr_u>`
+:math:`\I32.\ROTL`                   :math:`\hex{77}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-irotl>`
+:math:`\I32.\ROTR`                   :math:`\hex{78}`  :math:`[\I32~\I32] \to [\I32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-irotr>`
+:math:`\I64.\CLZ`                    :math:`\hex{79}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-iclz>`
+:math:`\I64.\CTZ`                    :math:`\hex{7A}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-ictz>`
+:math:`\I64.\POPCNT`                 :math:`\hex{7B}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-ipopcnt>`
+:math:`\I64.\ADD`                    :math:`\hex{7C}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-iadd>`
+:math:`\I64.\SUB`                    :math:`\hex{7D}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-isub>`
+:math:`\I64.\MUL`                    :math:`\hex{7E}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-imul>`
+:math:`\I64.\DIV\K{\_s}`             :math:`\hex{7F}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-idiv_s>`
+:math:`\I64.\DIV\K{\_u}`             :math:`\hex{80}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-idiv_u>`
+:math:`\I64.\REM\K{\_s}`             :math:`\hex{81}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-irem_s>`
+:math:`\I64.\REM\K{\_u}`             :math:`\hex{82}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-irem_u>`
+:math:`\I64.\AND`                    :math:`\hex{83}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-iand>`
+:math:`\I64.\OR`                     :math:`\hex{84}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ior>`
+:math:`\I64.\XOR`                    :math:`\hex{85}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ixor>`
+:math:`\I64.\SHL`                    :math:`\hex{86}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ishl>`
+:math:`\I64.\SHR\K{\_s}`             :math:`\hex{87}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ishr_s>`
+:math:`\I64.\SHR\K{\_u}`             :math:`\hex{88}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-ishr_u>`
+:math:`\I64.\ROTL`                   :math:`\hex{89}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-irotl>`
+:math:`\I64.\ROTR`                   :math:`\hex{8A}`  :math:`[\I64~\I64] \to [\I64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-irotr>`
+:math:`\F32.\ABS`                    :math:`\hex{8B}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fabs>`
+:math:`\F32.\NEG`                    :math:`\hex{8C}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fneg>`
+:math:`\F32.\CEIL`                   :math:`\hex{8D}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fceil>`
+:math:`\F32.\FLOOR`                  :math:`\hex{8E}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-ffloor>`
+:math:`\F32.\TRUNC`                  :math:`\hex{8F}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-ftrunc>`
+:math:`\F32.\NEAREST`                :math:`\hex{90}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fnearest>`
+:math:`\F32.\SQRT`                   :math:`\hex{91}`  :math:`[\F32] \to [\F32]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fsqrt>`
+:math:`\F32.\ADD`                    :math:`\hex{92}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fadd>`
+:math:`\F32.\SUB`                    :math:`\hex{93}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fsub>`
+:math:`\F32.\MUL`                    :math:`\hex{94}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fmul>`
+:math:`\F32.\DIV`                    :math:`\hex{95}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fdiv>`
+:math:`\F32.\FMIN`                   :math:`\hex{96}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fmin>`
+:math:`\F32.\FMAX`                   :math:`\hex{97}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fmax>`
+:math:`\F32.\COPYSIGN`               :math:`\hex{98}`  :math:`[\F32~\F32] \to [\F32]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fcopysign>`
+:math:`\F64.\ABS`                    :math:`\hex{99}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fabs>`
+:math:`\F64.\NEG`                    :math:`\hex{9A}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fneg>`
+:math:`\F64.\CEIL`                   :math:`\hex{9B}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fceil>`
+:math:`\F64.\FLOOR`                  :math:`\hex{9C}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-ffloor>`
+:math:`\F64.\TRUNC`                  :math:`\hex{9D}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-ftrunc>`
+:math:`\F64.\NEAREST`                :math:`\hex{9E}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fnearest>`
+:math:`\F64.\SQRT`                   :math:`\hex{9F}`  :math:`[\F64] \to [\F64]`                   :ref:`validation <valid-unop>`                   :ref:`execution <exec-unop>`, :ref:`operator <op-fsqrt>`
+:math:`\F64.\ADD`                    :math:`\hex{A0}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fadd>`
+:math:`\F64.\SUB`                    :math:`\hex{A1}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fsub>`
+:math:`\F64.\MUL`                    :math:`\hex{A2}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fmul>`
+:math:`\F64.\DIV`                    :math:`\hex{A3}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fdiv>`
+:math:`\F64.\FMIN`                   :math:`\hex{A4}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fmin>`
+:math:`\F64.\FMAX`                   :math:`\hex{A5}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fmax>`
+:math:`\F64.\COPYSIGN`               :math:`\hex{A6}`  :math:`[\F64~\F64] \to [\F64]`              :ref:`validation <valid-binop>`                  :ref:`execution <exec-binop>`, :ref:`operator <op-fcopysign>`
+:math:`\I32.\WRAP\K{/}\I64`          :math:`\hex{A7}`  :math:`[\I64] \to [\I32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-wrap>`
+:math:`\I32.\TRUNC\K{\_s/}\F32`      :math:`\hex{A8}`  :math:`[\F32] \to [\I32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_s>`
+:math:`\I32.\TRUNC\K{\_u/}\F32`      :math:`\hex{A9}`  :math:`[\F32] \to [\I32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_u>`
+:math:`\I32.\TRUNC\K{\_s/}\F64`      :math:`\hex{AA}`  :math:`[\F64] \to [\I32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_s>`
+:math:`\I32.\TRUNC\K{\_u/}\F64`      :math:`\hex{AB}`  :math:`[\F64] \to [\I32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_u>`
+:math:`\I64.\EXTEND\K{\_s/}\I32`     :math:`\hex{AC}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-extend_s>`
+:math:`\I64.\EXTEND\K{\_u/}\I32`     :math:`\hex{AD}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-extend_u>`
+:math:`\I64.\TRUNC\K{\_s/}\F32`      :math:`\hex{AE}`  :math:`[\F32] \to [\I64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_s>`
+:math:`\I64.\TRUNC\K{\_u/}\F32`      :math:`\hex{AF}`  :math:`[\F32] \to [\I64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_u>`
+:math:`\I64.\TRUNC\K{\_s/}\F64`      :math:`\hex{B0}`  :math:`[\F64] \to [\I64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_s>`
+:math:`\I64.\TRUNC\K{\_u/}\F64`      :math:`\hex{B1}`  :math:`[\F64] \to [\I64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-trunc_u>`
+:math:`\F32.\CONVERT\K{\_s/}\I32`    :math:`\hex{B2}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_s>`
+:math:`\F32.\CONVERT\K{\_u/}\I32`    :math:`\hex{B3}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_u>`
+:math:`\F32.\CONVERT\K{\_s/}\I64`    :math:`\hex{B4}`  :math:`[\I64] \to [\F32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_s>`
+:math:`\F32.\CONVERT\K{\_u/}\I64`    :math:`\hex{B5}`  :math:`[\I64] \to [\F32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_u>`
+:math:`\F32.\DEMOTE\K{/}\F64`        :math:`\hex{B6}`  :math:`[\F64] \to [\F32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-demote>`
+:math:`\F64.\CONVERT\K{\_s/}\I32`    :math:`\hex{B7}`  :math:`[\I32] \to [\F64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_s>`
+:math:`\F64.\CONVERT\K{\_u/}\I32`    :math:`\hex{B8}`  :math:`[\I32] \to [\F64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_u>`
+:math:`\F64.\CONVERT\K{\_s/}\I64`    :math:`\hex{B9}`  :math:`[\I64] \to [\F64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_s>`
+:math:`\F64.\CONVERT\K{\_u/}\I64`    :math:`\hex{BA}`  :math:`[\I64] \to [\F64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-convert_u>`
+:math:`\F64.\PROMOTE\K{/}\F32`       :math:`\hex{BB}`  :math:`[\F32] \to [\F64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-promote>`
+:math:`\I32.\REINTERPRET\K{/}\F32`   :math:`\hex{BC}`  :math:`[\F32] \to [\I32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
+:math:`\I64.\REINTERPRET\K{/}\F64`   :math:`\hex{BD}`  :math:`[\F64] \to [\I64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
+:math:`\F32.\REINTERPRET\K{/}\I32`   :math:`\hex{BE}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
+:math:`\F64.\REINTERPRET\K{/}\I64`   :math:`\hex{BF}`  :math:`[\I64] \to [\F64]`                   :ref:`validation <valid-cvtop>`                  :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
+===================================  ================  ==========================================  ===============================================  ===============================================================
 

--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -33,6 +33,8 @@ Control Instructions
 .. _binary-return:
 .. _binary-call:
 .. _binary-call_indirect:
+.. _binary-return_call:
+.. _binary-return_call_indirect:
 
 .. math::
    \begin{array}{llclll}
@@ -54,7 +56,9 @@ Control Instructions
        &\Rightarrow& \BRTABLE~l^\ast~l_N \\ &&|&
      \hex{0F} &\Rightarrow& \RETURN \\ &&|&
      \hex{10}~~x{:}\Bfuncidx &\Rightarrow& \CALL~x \\ &&|&
-     \hex{11}~~x{:}\Btypeidx~~\hex{00} &\Rightarrow& \CALLINDIRECT~x \\
+     \hex{11}~~x{:}\Btypeidx~~\hex{00} &\Rightarrow& \CALLINDIRECT~x \\ &&|&
+     \hex{12}~~x{:}\Bfuncidx &\Rightarrow& \RETURNCALL~x \\ &&|&
+     \hex{13}~~x{:}\Btypeidx~~\hex{00} &\Rightarrow& \RETURNCALLINDIRECT~x \\
    \end{array}
 
 .. note::
@@ -62,7 +66,7 @@ Control Instructions
 
 .. note::
    In future versions of WebAssembly, the zero byte occurring in the encoding
-   of the |CALLINDIRECT| instruction may be used to index additional tables.
+   of the |CALLINDIRECT| and |RETURNCALLINDIRECT| instructions may be used to index additional tables.
 
 .. index:: value type, polymorphism
    pair: binary format; instruction

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -844,7 +844,7 @@ Control Instructions
 .. math::
    ~\\[-1ex]
    \begin{array}{lcl@{\qquad}l}
-   \FRAME_n\{F\}~\XB^k[\val^n~\RETURN]~\END &\stepto& \val^n
+   \FRAME_n\{F\}~B^\ast[\val^n~\RETURN]~\END &\stepto& \val^n
    \end{array}
 
 
@@ -938,6 +938,8 @@ Control Instructions
 
 :math:`\RETURNCALL~x`
 .....................
+
+.. todo: find a way to reuse call/call_indirect prose for tail call versions
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
@@ -1127,11 +1129,11 @@ Tail-invocation of :ref:`function address <syntax-funcaddr>` :math:`a`
 
 1. Assert: due to :ref:`validation <valid-call>`, :math:`S.\SFUNCS[a]` exists.
 
-2. Let :math:`[t_1^m] \to [t_2^n]` be the :ref:`function type <syntax-functype>` :math:`S.\SFUNCS[a].\FITYPE`.
+2. Let :math:`[t_1^n] \to [t_2^m]` be the :ref:`function type <syntax-functype>` :math:`S.\SFUNCS[a].\FITYPE`.
 
 3. Assert: due to :ref:`validation <valid-return_call>`, there are at least :math:`m` values on the top of the stack.
 
-4. Pop the results :math:`\val^m` from the stack.
+4. Pop the results :math:`\val^n` from the stack.
 
 5. Assert: due to :ref:`validation <valid-return_call>`, the stack contains at least one :ref:`frame <syntax-frame>`.
 
@@ -1143,16 +1145,16 @@ Tail-invocation of :ref:`function address <syntax-funcaddr>` :math:`a`
 
 8. Pop the frame from the stack.
 
-9. Push :math:`\val^m` to the stack.
+9. Push :math:`\val^n` to the stack.
 
 10. :ref:`Invoke <exec-invoke>` the function instance at address :math:`a`.
 
 .. math::
    ~\\[-1ex]
    \begin{array}{lcl@{\qquad}l}
-    S; \FRAME_n\{F\}~B^*[\val^m~(\RETURNINVOKE~a)]~\END &\stepto&
-      \val^m~(\INVOKE~a)
-      & (\iff S.\SFUNCS[a].\FITYPE = [t_1^m] \to [t_2^n])
+    S; \FRAME_m\{F\}~B^\ast[\val^n~(\RETURNINVOKE~a)]~\END &\stepto&
+      \val^n~(\INVOKE~a)
+      & (\iff S.\SFUNCS[a].\FITYPE = [t_1^n] \to [t_2^m])
    \end{array}
 
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -934,6 +934,82 @@ Control Instructions
    \end{array}
 
 
+.. _exec-return_call:
+
+:math:`\RETURNCALL~x`
+.....................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-call>`, :math:`F.\AMODULE.\MIFUNCS[x]` exists.
+
+3. Let :math:`a` be the :ref:`function address <syntax-funcaddr>` :math:`F.\AMODULE.\MIFUNCS[x]`.
+
+4. :ref:`Tail-invoke <exec-return-invoke>` the function instance at address :math:`a`.
+
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (\RETURNCALL~x) &\stepto& (\RETURNINVOKE~a)
+     & (\iff \CALL~x \stepto \INVOKE~a)
+   \end{array}
+
+
+.. _exec-return_call_indirect:
+
+:math:`\RETURNCALLINDIRECT~x`
+.............................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`F.\AMODULE.\MITABLES[0]` exists.
+
+3. Let :math:`\X{ta}` be the :ref:`table address <syntax-tableaddr>` :math:`F.\AMODULE.\MITABLES[0]`.
+
+4. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`S.\STABLES[\X{ta}]` exists.
+
+5. Let :math:`\X{tab}` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}]`.
+
+6. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`F.\AMODULE.\MITYPES[x]` exists.
+
+7. Let :math:`\X{ft}_{\F{expect}}` be the :ref:`function type <syntax-functype>` :math:`F.\AMODULE.\MITYPES[x]`.
+
+8. Assert: due to :ref:`validation <valid-call_indirect>`, a value with :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+9. Pop the value :math:`\I32.\CONST~i` from the stack.
+
+10. If :math:`i` is not smaller than the length of :math:`\X{tab}.\TIELEM`, then:
+
+    a. Trap.
+
+11. If :math:`\X{tab}.\TIELEM[i]` is uninitialized, then:
+
+    a. Trap.
+
+12. Let :math:`a` be the :ref:`function address <syntax-funcaddr>` :math:`\X{tab}.\TIELEM[i]`.
+
+13. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`S.\SFUNCS[a]` exists.
+
+14. Let :math:`\X{f}` be the :ref:`function instance <syntax-funcinst>` :math:`S.\SFUNCS[a]`.
+
+15. Let :math:`\X{ft}_{\F{actual}}` be the :ref:`function type <syntax-functype>` :math:`\X{f}.\FITYPE`.
+
+16. If :math:`\X{ft}_{\F{actual}}` and :math:`\X{ft}_{\F{expect}}` differ, then:
+
+    a. Trap.
+
+17. :ref:`Tail-invoke <exec-return-invoke>` the function instance at address :math:`a`.
+
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (\RETURNCALLINDIRECT~x) &\stepto& (\RETURNINVOKE~a)
+     & (\iff \CALLINDIRECT~x \stepto \INVOKE~a) \\
+   (\RETURNCALLINDIRECT~x) &\stepto& \TRAP
+     & (\iff \CALLINDIRECT~x \stepto \TRAP) \\
+   \end{array}
+
+
 .. index:: instruction, instruction sequence, block
 .. _exec-instr-seq:
 
@@ -1041,6 +1117,42 @@ Invocation of :ref:`function address <syntax-funcaddr>` :math:`a`
      \wedge & f.\FICODE = \{ \FTYPE~x, \FLOCALS~t^k, \FBODY~\instr^\ast~\END \} \\
      \wedge & F = \{ \AMODULE~f.\FIMODULE, ~\ALOCALS~\val^n~(t.\CONST~0)^k \})
      \end{array} \\
+   \end{array}
+
+
+.. _exec-return-invoke:
+
+Tail-invocation of :ref:`function address <syntax-funcaddr>` :math:`a`
+......................................................................
+
+1. Assert: due to :ref:`validation <valid-call>`, :math:`S.\SFUNCS[a]` exists.
+
+2. Let :math:`[t_1^m] \to [t_2^n]` be the :ref:`function type <syntax-functype>` :math:`S.\SFUNCS[a].\FITYPE`.
+
+3. Assert: due to :ref:`validation <valid-return_call>`, there are at least :math:`m` values on the top of the stack.
+
+4. Pop the results :math:`\val^m` from the stack.
+
+5. Assert: due to :ref:`validation <valid-return_call>`, the stack contains at least one :ref:`frame <syntax-frame>`.
+
+6. While the top of the stack is not a frame, do:
+
+   a. Pop the top element from the stack.
+
+7. Assert: the top of the stack is a frame.
+
+8. Pop the frame from the stack.
+
+9. Push :math:`\val^m` to the stack.
+
+10. :ref:`Invoke <exec-invoke>` the function instance at address :math:`a`.
+
+.. math::
+   ~\\[-1ex]
+   \begin{array}{lcl@{\qquad}l}
+    S; \FRAME_n\{F\}~B^*[\val^m~(\RETURNINVOKE~a)]~\END &\stepto&
+      \val^m~(\INVOKE~a)
+      & (\iff S.\SFUNCS[a].\FITYPE = [t_1^m] \to [t_2^n])
    \end{array}
 
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -443,6 +443,7 @@ In order to express the reduction of :ref:`traps <trap>`, :ref:`calls <syntax-ca
      \dots \\ &&|&
      \TRAP \\ &&|&
      \INVOKE~\funcaddr \\ &&|&
+     \RETURNINVOKE~\funcaddr \\ &&|&
      \INITELEM~\tableaddr~\u32~\funcidx^\ast \\ &&|&
      \INITDATA~\memaddr~\u32~\byte^\ast \\ &&|&
      \LABEL_n\{\instr^\ast\}~\instr^\ast~\END \\ &&|&
@@ -454,6 +455,7 @@ Traps are bubbled up through nested instruction sequences, ultimately reducing t
 
 The |INVOKE| instruction represents the imminent invocation of a :ref:`function instance <syntax-funcinst>`, identified by its :ref:`address <syntax-funcaddr>`.
 It unifies the handling of different forms of calls.
+Analogously, |RETURNINVOKE| represents the imminent tail invocation of a function instance.
 
 The |INITELEM| and |INITDATA| instructions perform initialization of :ref:`element <syntax-elem>` and :ref:`data <syntax-data>` segments during module :ref:`instantiation <exec-instantiation>`.
 

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -301,7 +301,9 @@ Instructions in this group affect the flow of control.
      \BRTABLE~\vec(\labelidx)~\labelidx \\&&|&
      \RETURN \\&&|&
      \CALL~\funcidx \\&&|&
-     \CALLINDIRECT~\typeidx \\
+     \CALLINDIRECT~\typeidx \\&&|&
+     \RETURNCALL~\funcidx \\&&|&
+     \RETURNCALLINDIRECT~\typeidx \\
    \end{array}
 
 The |NOP| instruction does nothing.
@@ -344,9 +346,13 @@ The |CALLINDIRECT| instruction calls a function indirectly through an operand in
 Since tables may contain function elements of heterogeneous type |ANYFUNC|,
 the callee is dynamically checked against the :ref:`function type <syntax-functype>` indexed by the instruction's immediate, and the call aborted with a :ref:`trap <trap>` if it does not match.
 
+The |RETURNCALL| and |RETURNCALLINDIRECT| instructions are *tail-call* variants of the previous ones.
+That is, they first return from the current function before actually performing the respective call.
+It is guaranteed that no sequence of nested calls using only these instructions can cause resource exhaustion due to hitting an :ref:`implementation's limit <impl-exec>` on the number of active calls.
+
 .. note::
    In the current version of WebAssembly,
-   |CALLINDIRECT| implicitly operates on :ref:`table <syntax-table>` :ref:`index <syntax-tableidx>` :math:`0`.
+   |CALLINDIRECT| and |RETURNCALLINDIRECT| implicitly operate on :ref:`table <syntax-table>` :ref:`index <syntax-tableidx>` :math:`0`.
    This restriction may be lifted in future versions.
 
 

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -83,6 +83,8 @@ The same label identifier may optionally be repeated after the corresponding :ma
 .. _text-return:
 .. _text-call:
 .. _text-call_indirect:
+.. _text-return_call:
+.. _text-return_call_indirect:
 
 All other control instruction are represented verbatim.
 
@@ -98,6 +100,9 @@ All other control instruction are represented verbatim.
      \text{return} &\Rightarrow& \RETURN \\ &&|&
      \text{call}~~x{:}\Tfuncidx_I &\Rightarrow& \CALL~x \\ &&|&
      \text{call\_indirect}~~x,I'{:}\Ttypeuse_I &\Rightarrow& \CALLINDIRECT~x
+       & (\iff I' = \{\}) \\ &&|&
+     \text{return\_call}~~x{:}\Tfuncidx_I &\Rightarrow& \RETURNCALL~x \\ &&|&
+     \text{return\_call\_indirect}~~x,I'{:}\Ttypeuse_I &\Rightarrow& \RETURNCALLINDIRECT~x
        & (\iff I' = \{\}) \\
    \end{array}
 

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -313,6 +313,8 @@
 .. |RETURN| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{return}}
 .. |CALL| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{call}}
 .. |CALLINDIRECT| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{call\_indirect}}
+.. |RETURNCALL| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{return\_call}}
+.. |RETURNCALLINDIRECT| mathdef:: \xref{syntax/instructions}{syntax-instr-control}{\K{return\_call\_indirect}}
 
 .. |DROP| mathdef:: \xref{syntax/instructions}{syntax-instr-parametric}{\K{drop}}
 .. |SELECT| mathdef:: \xref{syntax/instructions}{syntax-instr-parametric}{\K{select}}
@@ -865,6 +867,7 @@
 
 .. |TRAP| mathdef:: \xref{exec/runtime}{syntax-trap}{\K{trap}}
 .. |INVOKE| mathdef:: \xref{exec/runtime}{syntax-invoke}{\K{invoke}}
+.. |RETURNINVOKE| mathdef:: \xref{exec/runtime}{syntax-return_invoke}{\K{return\_invoke}}
 .. |INITELEM| mathdef:: \xref{exec/runtime}{syntax-init_elem}{\K{init\_elem}}
 .. |INITDATA| mathdef:: \xref{exec/runtime}{syntax-init_data}{\K{init\_data}}
 

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -686,13 +686,13 @@ Control Instructions
 :math:`\RETURNCALL~x`
 .....................
 
-* The return type :math:`C.\CRETURN` must not be empty in the context.
+* The return type :math:`C.\CRETURN` must not be absent in the context.
 
 * The function :math:`C.\CFUNCS[x]` must be defined in the context.
 
 * Let :math:`[t_1^\ast] \to [t_2^?]` be the :ref:`function type <syntax-functype>` :math:`C.\CFUNCS[x]`.
 
-* The :ref:`result type <syntax-resulttype>` must be the same as :math:`C.\CRETURN`.
+* The :ref:`result type <syntax-resulttype>` :math:`[t_2^?]` must be the same as :math:`C.\CRETURN`.
 
 * Then the instruction is valid with type :math:`[t_3^\ast~t_1^\ast] \to [t_4^\ast]`, for any sequences of :ref:`value types <syntax-valtype>` :math:`t_3^\ast` and :math:`t_4^\ast`.
 
@@ -702,7 +702,7 @@ Control Instructions
      \qquad
      C.\CRETURN = [t_2^?]
    }{
-     C \vdashinstr \CALL~x : [t_3^\ast~t_1^\ast] \to [t_4^\ast]
+     C \vdashinstr \RETURNCALL~x : [t_3^\ast~t_1^\ast] \to [t_4^\ast]
    }
 
 .. note::
@@ -726,6 +726,8 @@ Control Instructions
 
 * Let :math:`[t_1^\ast] \to [t_2^?]` be the :ref:`function type <syntax-functype>` :math:`C.\CTYPES[x]`.
 
+* The :ref:`result type <syntax-resulttype>` :math:`[t_2^?]` must be the same as :math:`C.\CRETURN`.
+
 * Then the instruction is valid with type :math:`[t_3^\ast~t_1^\ast~\I32] \to [t_4^\ast]`, for any sequences of :ref:`value types <syntax-valtype>` :math:`t_3^\ast` and :math:`t_4^\ast`.
 
 
@@ -737,7 +739,7 @@ Control Instructions
      \qquad
      C.\CRETURN = [t_2^?]
    }{
-     C \vdashinstr \CALLINDIRECT~x : [t_3^\ast~t_1^\ast~\I32] \to [t_4^\ast]
+     C \vdashinstr \RETURNCALLINDIRECT~x : [t_3^\ast~t_1^\ast~\I32] \to [t_4^\ast]
    }
 
 .. note::

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -681,6 +681,69 @@ Control Instructions
    }
 
 
+.. _valid-return_call:
+
+:math:`\RETURNCALL~x`
+.....................
+
+* The return type :math:`C.\CRETURN` must not be empty in the context.
+
+* The function :math:`C.\CFUNCS[x]` must be defined in the context.
+
+* Let :math:`[t_1^\ast] \to [t_2^?]` be the :ref:`function type <syntax-functype>` :math:`C.\CFUNCS[x]`.
+
+* The :ref:`result type <syntax-resulttype>` must be the same as :math:`C.\CRETURN`.
+
+* Then the instruction is valid with type :math:`[t_3^\ast~t_1^\ast] \to [t_4^\ast]`, for any sequences of :ref:`value types <syntax-valtype>` :math:`t_3^\ast` and :math:`t_4^\ast`.
+
+.. math::
+   \frac{
+     C.\CFUNCS[x] = [t_1^\ast] \to [t_2^?]
+     \qquad
+     C.\CRETURN = [t_2^?]
+   }{
+     C \vdashinstr \CALL~x : [t_3^\ast~t_1^\ast] \to [t_4^\ast]
+   }
+
+.. note::
+   The |RETURNCALL| instruction is :ref:`stack-polymorphic <polymorphism>`.
+
+
+.. _valid-return_call_indirect:
+
+:math:`\RETURNCALLINDIRECT~x`
+.............................
+
+* The return type :math:`C.\CRETURN` must not be empty in the context.
+
+* The table :math:`C.\CTABLES[0]` must be defined in the context.
+
+* Let :math:`\limits~\elemtype` be the :ref:`table type <syntax-tabletype>` :math:`C.\CTABLES[0]`.
+
+* The :ref:`element type <syntax-elemtype>` :math:`\elemtype` must be |ANYFUNC|.
+
+* The type :math:`C.\CTYPES[x]` must be defined in the context.
+
+* Let :math:`[t_1^\ast] \to [t_2^?]` be the :ref:`function type <syntax-functype>` :math:`C.\CTYPES[x]`.
+
+* Then the instruction is valid with type :math:`[t_3^\ast~t_1^\ast~\I32] \to [t_4^\ast]`, for any sequences of :ref:`value types <syntax-valtype>` :math:`t_3^\ast` and :math:`t_4^\ast`.
+
+
+.. math::
+   \frac{
+     C.\CTABLES[0] = \limits~\ANYFUNC
+     \qquad
+     C.\CTYPES[x] = [t_1^\ast] \to [t_2^?]
+     \qquad
+     C.\CRETURN = [t_2^?]
+   }{
+     C \vdashinstr \CALLINDIRECT~x : [t_3^\ast~t_1^\ast~\I32] \to [t_4^\ast]
+   }
+
+.. note::
+   The |RETURNCALLINDIRECT| instruction is :ref:`stack-polymorphic <polymorphism>`.
+
+
 .. index:: instruction, instruction sequence
 .. _valid-instr-seq:
 

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -214,6 +214,8 @@ op:
   br_if <var>
   br_table <var>+
   return
+  return_call <var>
+  return_call_indirect <func_type>
   call <var>
   call_indirect <func_type>
   drop

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -246,8 +246,13 @@ let rec instr s =
     let x = at var s in
     expect 0x00 s "zero flag expected";
     call_indirect x
+  | 0x12 -> return_call (at var s)
+  | 0x13 ->
+    let x = at var s in
+    expect 0x00 s "zero flag expected";
+    return_call_indirect x
 
-  | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 as b -> illegal s pos b
+  | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 as b -> illegal s pos b
 
   | 0x1a -> drop
   | 0x1b -> select

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -157,6 +157,8 @@ let encode m =
       | Return -> op 0x0f
       | Call x -> op 0x10; var x
       | CallIndirect x -> op 0x11; var x; u8 0x00
+      | ReturnCall x -> op 0x12; var x
+      | ReturnCallIndirect x -> op 0x13; var x; u8 0x00
 
       | Drop -> op 0x1a
       | Select -> op 0x1b

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -82,6 +82,8 @@ and instr' =
   | Return                            (* break from function body *)
   | Call of var                       (* call function *)
   | CallIndirect of var               (* call function through table *)
+  | ReturnCall of var                 (* tail-call function *)
+  | ReturnCallIndirect of var         (* tail-call function through table *)
   | GetLocal of var                   (* read local variable *)
   | SetLocal of var                   (* write local variable *)
   | TeeLocal of var                   (* write local variable and keep value *)

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -24,6 +24,8 @@ let if_ ts es1 es2 = If (ts, es1, es2)
 let return = Return
 let call x = Call x
 let call_indirect x = CallIndirect x
+let return_call x = ReturnCall x
+let return_call_indirect x = ReturnCallIndirect x
 
 let get_local x = GetLocal x
 let set_local x = SetLocal x

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -237,6 +237,9 @@ let rec instr e =
     | Return -> "return", []
     | Call x -> "call " ^ var x, []
     | CallIndirect x -> "call_indirect", [Node ("type " ^ var x, [])]
+    | ReturnCall x -> "return_call " ^ var x, []
+    | ReturnCallIndirect x ->
+      "return_call_indirect", [Node ("type " ^ var x, [])]
     | GetLocal x -> "get_local " ^ var x, []
     | SetLocal x -> "set_local " ^ var x, []
     | TeeLocal x -> "tee_local " ^ var x, []

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -192,6 +192,8 @@ rule token = parse
   | "select" { SELECT }
   | "call" { CALL }
   | "call_indirect" { CALL_INDIRECT }
+  | "return_call" { RETURN_CALL }
+  | "return_call_indirect" { RETURN_CALL_INDIRECT }
 
   | "get_local" { GET_LOCAL }
   | "set_local" { SET_LOCAL }

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -228,7 +228,16 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
     let FuncType (ins, out) = type_ c x in
     (ins @ [I32Type]) --> out
 
+  | ReturnCall x ->
+    let FuncType (ins, out) = func c x in
+    require (out = c.results) e.at "type mismatch in function result";
+    ins -->... []
 
+  | ReturnCallIndirect x ->
+    ignore (table c (0l @@ e.at));
+    let FuncType (ins, out) = type_ c x in
+    require (out = c.results) e.at "type mismatch in function result";
+    (ins @ [I32Type]) -->... []
 
   | GetLocal x ->
     [] --> [local c x]

--- a/proposals/tail-call/Overview.md
+++ b/proposals/tail-call/Overview.md
@@ -27,23 +27,38 @@ This can be applied to any form of call, that is:
 
 ### Instructions
 
-* Tail calls should be explicit instructions (current instructions explicitly disallow TCE)
+* Tail calls should be separate, explicit call instructions (current instructions explicitly disallow TCE)
 
 * Two possible schemes:
   1. introduce tail version of every call instruction
   2. introduce single prefix instruction that can be applied to every call instruction
 
-Note: WebAssembly will likely get more call instructions in the future, e.g., `call_ptr`.
+* Consideration: WebAssembly will likely get more call instructions in the future, e.g., `call_ref`
+
+
+### Execution
+
+* Tail calls behave like a combination of `return` followed by a respective call
+
+* Hence they unwind the operand stack like `return` does
+
+* Only keeps the necessary call arguments
 
 
 ### Typing
 
-* Two options:
-  1. All functions are tail-callable
-  2. Tail-callable functions are distinguished by type
+* Because tail calls transfer control and unwind the stack they are stack-polymorphic:
 
-Option 2 allows different calling conventions for non-tail-callable functions, which may be reduce constraints on ABIs.
-On the other hand, it creates a bifurcated function space, which might lead to difficulties e.g. when using function tables or other forms of dynamic indirection.
+* Open question: distinguish tail-calls in function type? Possibilities:
+  1. Distinguish tail-callees by type
+  2. Distinguish tail-callers by type
+  3. Both
+  4. Neither
+
+* Considerations:
+  - Option 1 (and 3) allows different calling conventions for non-tail-callable functions, which may be reduce constraints on ABIs.
+  - On the other hand, it creates a bifurcated function space, which can lead to difficulties e.g. when using function tables or other forms of dynamic indirection.
+  - Benefit of option 2 (and 3) unclear.
 
 
 ## Examples
@@ -74,12 +89,15 @@ A simple boring example of a tail-recursive factorial funciton.
 For now, we assume that separate instructions are introduced.
 It is not difficult to adapt the rules to an alternative design with instruction prefixes.
 
+The details of possible typing refinements to distinguish tail-callers/callees are to be discussed and not yet included.
+
+
 ### Structure
 
 Add two instructions (for now):
 
-* `return_call x`, the tail-call version of `call`
-* `return_call_indirect x`, the tail-call version of `call_indirect`
+* `return_call <funcidx>`, the tail-call version of `call`
+* `return_call_indirect <tableidx> <typeidx>`, the tail-call version of `call_indirect`
 
 
 ### Validation
@@ -87,14 +105,16 @@ Add two instructions (for now):
 Validation of the new instructions is simply a combination of the typing rules for `return` and those for basic calls (and thus is stack-polymorphic).
 
 * If `x` refers to a function of type \[t1\*\] -> \[t2\*\],
-  then the instruction `return_call x` has type \[t3\* t1\*\] -> \[t4\* t2\*\],
-  for any t3\* and t4\*.
+  then the instruction `return_call x` has type \[t3\* t1\*\] -> \[t4\*\],
+  for any t3\* and t4\*,
+  provided that the current function has return type \[t2\*\].
 
 * If `x` refers to a function type \[t1\*\] -> \[t2\*\],
-  then the instruction `return_call_indirect x` has type \[t3\* t1\* i32\] -> \[t4\* t2\*\],
-  for any t3\* and t4\*.
+  then the instruction `return_call_indirect x` has type \[t3\* t1\* i32\] -> \[t4\*\],
+  for any t3\* and t4\*,
+  provided that the current function has return type \[t2\*\].
 
-Note that caller and callee type do not need to match.
+Note that caller's and callee's parameter types do not need to match.
 
 
 ### Execution
@@ -109,8 +129,10 @@ Execution semantics of the new instructions would
 
 ### Binary Format
 
-Need to assign opcodes for the new instructions.
-Fortunately (and not just coincidentally), there is reserved opcode space next to the existing call instructions.
+Use the reserved opcodes after existing call instructions, i.e.:
+
+* `return_call` is 0x12
+* `return_call_indirect` is 0x13
 
 
 ### Text Format
@@ -120,13 +142,13 @@ The text format is extended with two new instructions in the obvious manner.
 
 ## Open Questions
 
-* Differentiate tail-callable functions by type?
+* Which instruction scheme should be picked?
+
+* Differentiate tail-callers or callees by type?
 
 * What about tail calls to host functions?
   - treat as tail-calling a wrapper, use type distinction, or trap?
   - note: cannot distinguish statically without type system support, e.g. with indirect calls
-
-* Which instruction scheme should be picked?
 
 * Instruction name bikeshedding
 

--- a/test/core/return_call.wast
+++ b/test/core/return_call.wast
@@ -1,0 +1,202 @@
+;; Test `call` operator
+
+(module
+  ;; Auxiliary definitions
+  (func $const-i32 (result i32) (i32.const 0x132))
+  (func $const-i64 (result i64) (i64.const 0x164))
+  (func $const-f32 (result f32) (f32.const 0xf32))
+  (func $const-f64 (result f64) (f64.const 0xf64))
+
+  (func $id-i32 (param i32) (result i32) (get_local 0))
+  (func $id-i64 (param i64) (result i64) (get_local 0))
+  (func $id-f32 (param f32) (result f32) (get_local 0))
+  (func $id-f64 (param f64) (result f64) (get_local 0))
+
+  (func $f32-i32 (param f32 i32) (result i32) (get_local 1))
+  (func $i32-i64 (param i32 i64) (result i64) (get_local 1))
+  (func $f64-f32 (param f64 f32) (result f32) (get_local 1))
+  (func $i64-f64 (param i64 f64) (result f64) (get_local 1))
+
+  ;; Typing
+
+  (func (export "type-i32") (result i32) (call $const-i32))
+  (func (export "type-i64") (result i64) (call $const-i64))
+  (func (export "type-f32") (result f32) (call $const-f32))
+  (func (export "type-f64") (result f64) (call $const-f64))
+
+  (func (export "type-first-i32") (result i32) (call $id-i32 (i32.const 32)))
+  (func (export "type-first-i64") (result i64) (call $id-i64 (i64.const 64)))
+  (func (export "type-first-f32") (result f32) (call $id-f32 (f32.const 1.32)))
+  (func (export "type-first-f64") (result f64) (call $id-f64 (f64.const 1.64)))
+
+  (func (export "type-second-i32") (result i32)
+    (return_call $f32-i32 (f32.const 32.1) (i32.const 32))
+  )
+  (func (export "type-second-i64") (result i64)
+    (return_call $i32-i64 (i32.const 32) (i64.const 64))
+  )
+  (func (export "type-second-f32") (result f32)
+    (return_call $f64-f32 (f64.const 64) (f32.const 32))
+  )
+  (func (export "type-second-f64") (result f64)
+    (return_call $i64-f64 (i64.const 64) (f64.const 64.1))
+  )
+
+  ;; Recursion
+
+  (func $fac-acc (export "fac-acc") (param i64 i64) (result i64)
+    (if (result i64) (i64.eqz (get_local 0))
+      (then (get_local 1))
+      (else
+        (return_call $fac-acc
+          (i64.sub (get_local 0) (i64.const 1))
+          (i64.mul (get_local 0) (get_local 1))
+        )
+      )
+    )
+  )
+
+  (func $count (export "count") (param i64) (result i64)
+    (if (result i64) (i64.eqz (get_local 0))
+      (then (get_local 0))
+      (else (return_call $count (i64.sub (get_local 0) (i64.const 1))))
+    )
+  )
+
+  (func $even (export "even") (param i64) (result i32)
+    (if (result i32) (i64.eqz (get_local 0))
+      (then (i32.const 44))
+      (else (return_call $odd (i64.sub (get_local 0) (i64.const 1))))
+    )
+  )
+  (func $odd (export "odd") (param i64) (result i32)
+    (if (result i32) (i64.eqz (get_local 0))
+      (then (i32.const 99))
+      (else (return_call $even (i64.sub (get_local 0) (i64.const 1))))
+    )
+  )
+)
+
+(assert_return (invoke "type-i32") (i32.const 0x132))
+(assert_return (invoke "type-i64") (i64.const 0x164))
+(assert_return (invoke "type-f32") (f32.const 0xf32))
+(assert_return (invoke "type-f64") (f64.const 0xf64))
+
+(assert_return (invoke "type-first-i32") (i32.const 32))
+(assert_return (invoke "type-first-i64") (i64.const 64))
+(assert_return (invoke "type-first-f32") (f32.const 1.32))
+(assert_return (invoke "type-first-f64") (f64.const 1.64))
+
+(assert_return (invoke "type-second-i32") (i32.const 32))
+(assert_return (invoke "type-second-i64") (i64.const 64))
+(assert_return (invoke "type-second-f32") (f32.const 32))
+(assert_return (invoke "type-second-f64") (f64.const 64.1))
+
+(assert_return (invoke "fac-acc" (i64.const 0) (i64.const 1)) (i64.const 1))
+(assert_return (invoke "fac-acc" (i64.const 1) (i64.const 1)) (i64.const 1))
+(assert_return (invoke "fac-acc" (i64.const 5) (i64.const 1)) (i64.const 120))
+(assert_return
+  (invoke "fac-acc" (i64.const 25) (i64.const 1))
+  (i64.const 7034535277573963776)
+)
+
+(assert_return (invoke "count" (i64.const 0)) (i64.const 0))
+(assert_return (invoke "count" (i64.const 1000)) (i64.const 0))
+(assert_return (invoke "count" (i64.const 1_000_000)) (i64.const 0))
+
+(assert_return (invoke "even" (i64.const 0)) (i32.const 44))
+(assert_return (invoke "even" (i64.const 1)) (i32.const 99))
+(assert_return (invoke "even" (i64.const 100)) (i32.const 44))
+(assert_return (invoke "even" (i64.const 77)) (i32.const 99))
+(assert_return (invoke "even" (i64.const 1_000_000)) (i32.const 44))
+(assert_return (invoke "even" (i64.const 1_000_001)) (i32.const 99))
+(assert_return (invoke "odd" (i64.const 0)) (i32.const 99))
+(assert_return (invoke "odd" (i64.const 1)) (i32.const 44))
+(assert_return (invoke "odd" (i64.const 200)) (i32.const 99))
+(assert_return (invoke "odd" (i64.const 77)) (i32.const 44))
+(assert_return (invoke "odd" (i64.const 1_000_000)) (i32.const 99))
+(assert_return (invoke "odd" (i64.const 999_999)) (i32.const 44))
+
+
+;; Invalid typing
+
+(assert_invalid
+  (module
+    (func $type-void-vs-num (result i32) (return_call 1) (i32.const 0))
+    (func)
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-num-vs-num (result i32) (return_call 1) (i32.const 0))
+    (func (result i64) (i64.const 1))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (func $arity-0-vs-1 (return_call 1))
+    (func (param i32))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $arity-0-vs-2 (return_call 1))
+    (func (param f64 i32))
+  )
+  "type mismatch"
+)
+
+(module
+  (func $arity-1-vs-0 (i32.const 1) (return_call 1))
+  (func)
+)
+
+(module
+  (func $arity-2-vs-0 (f64.const 2) (i32.const 1) (return_call 1))
+  (func)
+)
+
+(assert_invalid
+  (module
+    (func $type-first-void-vs-num (return_call 1 (nop) (i32.const 1)))
+    (func (param i32 i32))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-second-void-vs-num (return_call 1 (i32.const 1) (nop)))
+    (func (param i32 i32))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-first-num-vs-num (return_call 1 (f64.const 1) (i32.const 1)))
+    (func (param i32 f64))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-second-num-vs-num (return_call 1 (i32.const 1) (f64.const 1)))
+    (func (param f64 i32))
+  )
+  "type mismatch"
+)
+
+
+;; Unbound function
+
+(assert_invalid
+  (module (func $unbound-func (return_call 1)))
+  "unknown function"
+)
+(assert_invalid
+  (module (func $large-func (return_call 1012321300)))
+  "unknown function"
+)

--- a/test/core/return_call.wast
+++ b/test/core/return_call.wast
@@ -1,4 +1,4 @@
-;; Test `call` operator
+;; Test `return_call` operator
 
 (module
   ;; Auxiliary definitions
@@ -19,15 +19,15 @@
 
   ;; Typing
 
-  (func (export "type-i32") (result i32) (call $const-i32))
-  (func (export "type-i64") (result i64) (call $const-i64))
-  (func (export "type-f32") (result f32) (call $const-f32))
-  (func (export "type-f64") (result f64) (call $const-f64))
+  (func (export "type-i32") (result i32) (return_call $const-i32))
+  (func (export "type-i64") (result i64) (return_call $const-i64))
+  (func (export "type-f32") (result f32) (return_call $const-f32))
+  (func (export "type-f64") (result f64) (return_call $const-f64))
 
-  (func (export "type-first-i32") (result i32) (call $id-i32 (i32.const 32)))
-  (func (export "type-first-i64") (result i64) (call $id-i64 (i64.const 64)))
-  (func (export "type-first-f32") (result f32) (call $id-f32 (f32.const 1.32)))
-  (func (export "type-first-f64") (result f64) (call $id-f64 (f64.const 1.64)))
+  (func (export "type-first-i32") (result i32) (return_call $id-i32 (i32.const 32)))
+  (func (export "type-first-i64") (result i64) (return_call $id-i64 (i64.const 64)))
+  (func (export "type-first-f32") (result f32) (return_call $id-f32 (f32.const 1.32)))
+  (func (export "type-first-f64") (result f64) (return_call $id-f64 (f64.const 1.64)))
 
   (func (export "type-second-i32") (result i32)
     (return_call $f32-i32 (f32.const 32.1) (i32.const 32))

--- a/test/core/return_call_indirect.wast
+++ b/test/core/return_call_indirect.wast
@@ -1,4 +1,4 @@
-;; Test `call_indirect` operator
+;; Test `return_call_indirect` operator
 
 (module
   ;; Auxiliary definitions

--- a/test/core/return_call_indirect.wast
+++ b/test/core/return_call_indirect.wast
@@ -1,0 +1,511 @@
+;; Test `call_indirect` operator
+
+(module
+  ;; Auxiliary definitions
+  (type $proc (func))
+  (type $out-i32 (func (result i32)))
+  (type $out-i64 (func (result i64)))
+  (type $out-f32 (func (result f32)))
+  (type $out-f64 (func (result f64)))
+  (type $over-i32 (func (param i32) (result i32)))
+  (type $over-i64 (func (param i64) (result i64)))
+  (type $over-f32 (func (param f32) (result f32)))
+  (type $over-f64 (func (param f64) (result f64)))
+  (type $f32-i32 (func (param f32 i32) (result i32)))
+  (type $i32-i64 (func (param i32 i64) (result i64)))
+  (type $f64-f32 (func (param f64 f32) (result f32)))
+  (type $i64-f64 (func (param i64 f64) (result f64)))
+  (type $over-i32-duplicate (func (param i32) (result i32)))
+  (type $over-i64-duplicate (func (param i64) (result i64)))
+  (type $over-f32-duplicate (func (param f32) (result f32)))
+  (type $over-f64-duplicate (func (param f64) (result f64)))
+
+  (func $const-i32 (type $out-i32) (i32.const 0x132))
+  (func $const-i64 (type $out-i64) (i64.const 0x164))
+  (func $const-f32 (type $out-f32) (f32.const 0xf32))
+  (func $const-f64 (type $out-f64) (f64.const 0xf64))
+
+  (func $id-i32 (type $over-i32) (get_local 0))
+  (func $id-i64 (type $over-i64) (get_local 0))
+  (func $id-f32 (type $over-f32) (get_local 0))
+  (func $id-f64 (type $over-f64) (get_local 0))
+
+  (func $i32-i64 (type $i32-i64) (get_local 1))
+  (func $i64-f64 (type $i64-f64) (get_local 1))
+  (func $f32-i32 (type $f32-i32) (get_local 1))
+  (func $f64-f32 (type $f64-f32) (get_local 1))
+
+  (func $over-i32-duplicate (type $over-i32-duplicate) (get_local 0))
+  (func $over-i64-duplicate (type $over-i64-duplicate) (get_local 0))
+  (func $over-f32-duplicate (type $over-f32-duplicate) (get_local 0))
+  (func $over-f64-duplicate (type $over-f64-duplicate) (get_local 0))
+
+  (table anyfunc
+    (elem
+      $const-i32 $const-i64 $const-f32 $const-f64
+      $id-i32 $id-i64 $id-f32 $id-f64
+      $f32-i32 $i32-i64 $f64-f32 $i64-f64
+      $fac $fac-acc $even $odd
+      $over-i32-duplicate $over-i64-duplicate
+      $over-f32-duplicate $over-f64-duplicate
+    )
+  )
+
+  ;; Syntax
+
+  (func
+    (return_call_indirect (i32.const 0))
+    (return_call_indirect (param i64) (i64.const 0) (i32.const 0))
+    (return_call_indirect (param i64) (param) (param f64 i32 i64)
+      (i64.const 0) (f64.const 0) (i32.const 0) (i64.const 0) (i32.const 0)
+    )
+    (return_call_indirect (result) (i32.const 0))
+  )
+
+  (func (result i32)
+    (return_call_indirect (result i32) (i32.const 0))
+    (return_call_indirect (result i32) (result) (i32.const 0))
+    (return_call_indirect (param i64) (result i32) (i64.const 0) (i32.const 0))
+    (return_call_indirect
+      (param) (param i64) (param) (param f64 i32 i64) (param) (param)
+      (result) (result i32) (result) (result)
+      (i64.const 0) (f64.const 0) (i32.const 0) (i64.const 0) (i32.const 0)
+    )
+  )
+
+  (func (result i64)
+    (return_call_indirect (type $over-i64) (param i64) (result i64)
+      (i64.const 0) (i32.const 0)
+    )
+  )
+
+  ;; Typing
+
+  (func (export "type-i32") (result i32)
+    (return_call_indirect (type $out-i32) (i32.const 0))
+  )
+  (func (export "type-i64") (result i64)
+    (return_call_indirect (type $out-i64) (i32.const 1))
+  )
+  (func (export "type-f32") (result f32)
+    (return_call_indirect (type $out-f32) (i32.const 2))
+  )
+  (func (export "type-f64") (result f64)
+    (return_call_indirect (type $out-f64) (i32.const 3))
+  )
+
+  (func (export "type-index") (result i64)
+    (return_call_indirect (type $over-i64) (i64.const 100) (i32.const 5))
+  )
+
+  (func (export "type-first-i32") (result i32)
+    (return_call_indirect (type $over-i32) (i32.const 32) (i32.const 4))
+  )
+  (func (export "type-first-i64") (result i64)
+    (return_call_indirect (type $over-i64) (i64.const 64) (i32.const 5))
+  )
+  (func (export "type-first-f32") (result f32)
+    (return_call_indirect (type $over-f32) (f32.const 1.32) (i32.const 6))
+  )
+  (func (export "type-first-f64") (result f64)
+    (return_call_indirect (type $over-f64) (f64.const 1.64) (i32.const 7))
+  )
+
+  (func (export "type-second-i32") (result i32)
+    (return_call_indirect (type $f32-i32)
+      (f32.const 32.1) (i32.const 32) (i32.const 8)
+    )
+  )
+  (func (export "type-second-i64") (result i64)
+    (return_call_indirect (type $i32-i64)
+      (i32.const 32) (i64.const 64) (i32.const 9)
+    )
+  )
+  (func (export "type-second-f32") (result f32)
+    (return_call_indirect (type $f64-f32)
+      (f64.const 64) (f32.const 32) (i32.const 10)
+    )
+  )
+  (func (export "type-second-f64") (result f64)
+    (return_call_indirect (type $i64-f64)
+      (i64.const 64) (f64.const 64.1) (i32.const 11)
+    )
+  )
+
+  ;; Dispatch
+
+  (func (export "dispatch") (param i32 i64) (result i64)
+    (return_call_indirect (type $over-i64) (get_local 1) (get_local 0))
+  )
+
+  (func (export "dispatch-structural") (param i32) (result i64)
+    (return_call_indirect (type $over-i64-duplicate)
+      (i64.const 9) (get_local 0)
+    )
+  )
+
+  ;; Recursion
+
+  (func $fac (export "fac") (type $over-i64)
+    (return_call_indirect (param i64 i64) (result i64)
+      (get_local 0) (i64.const 1) (i32.const 13)
+    )
+  )
+
+  (func $fac-acc (param i64 i64) (result i64)
+    (if (result i64) (i64.eqz (get_local 0))
+      (then (get_local 1))
+      (else
+        (return_call_indirect (param i64 i64) (result i64)
+          (i64.sub (get_local 0) (i64.const 1))
+          (i64.mul (get_local 0) (get_local 1))
+          (i32.const 13)
+        )
+      )
+    )
+  )
+
+  (func $even (export "even") (param i32) (result i32)
+    (if (result i32) (i32.eqz (get_local 0))
+      (then (i32.const 44))
+      (else
+        (return_call_indirect (type $over-i32)
+          (i32.sub (get_local 0) (i32.const 1))
+          (i32.const 15)
+        )
+      )
+    )
+  )
+  (func $odd (export "odd") (param i32) (result i32)
+    (if (result i32) (i32.eqz (get_local 0))
+      (then (i32.const 99))
+      (else
+        (return_call_indirect (type $over-i32)
+          (i32.sub (get_local 0) (i32.const 1))
+          (i32.const 14)
+        )
+      )
+    )
+  )
+)
+
+(assert_return (invoke "type-i32") (i32.const 0x132))
+(assert_return (invoke "type-i64") (i64.const 0x164))
+(assert_return (invoke "type-f32") (f32.const 0xf32))
+(assert_return (invoke "type-f64") (f64.const 0xf64))
+
+(assert_return (invoke "type-index") (i64.const 100))
+
+(assert_return (invoke "type-first-i32") (i32.const 32))
+(assert_return (invoke "type-first-i64") (i64.const 64))
+(assert_return (invoke "type-first-f32") (f32.const 1.32))
+(assert_return (invoke "type-first-f64") (f64.const 1.64))
+
+(assert_return (invoke "type-second-i32") (i32.const 32))
+(assert_return (invoke "type-second-i64") (i64.const 64))
+(assert_return (invoke "type-second-f32") (f32.const 32))
+(assert_return (invoke "type-second-f64") (f64.const 64.1))
+
+(assert_return (invoke "dispatch" (i32.const 5) (i64.const 2)) (i64.const 2))
+(assert_return (invoke "dispatch" (i32.const 5) (i64.const 5)) (i64.const 5))
+(assert_return (invoke "dispatch" (i32.const 12) (i64.const 5)) (i64.const 120))
+(assert_return (invoke "dispatch" (i32.const 17) (i64.const 2)) (i64.const 2))
+(assert_trap (invoke "dispatch" (i32.const 0) (i64.const 2)) "indirect call type mismatch")
+(assert_trap (invoke "dispatch" (i32.const 15) (i64.const 2)) "indirect call type mismatch")
+(assert_trap (invoke "dispatch" (i32.const 20) (i64.const 2)) "undefined element")
+(assert_trap (invoke "dispatch" (i32.const -1) (i64.const 2)) "undefined element")
+(assert_trap (invoke "dispatch" (i32.const 1213432423) (i64.const 2)) "undefined element")
+
+(assert_return (invoke "dispatch-structural" (i32.const 5)) (i64.const 9))
+(assert_return (invoke "dispatch-structural" (i32.const 5)) (i64.const 9))
+(assert_return (invoke "dispatch-structural" (i32.const 12)) (i64.const 362880))
+(assert_return (invoke "dispatch-structural" (i32.const 17)) (i64.const 9))
+(assert_trap (invoke "dispatch-structural" (i32.const 11)) "indirect call type mismatch")
+(assert_trap (invoke "dispatch-structural" (i32.const 16)) "indirect call type mismatch")
+
+(assert_return (invoke "fac" (i64.const 0)) (i64.const 1))
+(assert_return (invoke "fac" (i64.const 1)) (i64.const 1))
+(assert_return (invoke "fac" (i64.const 5)) (i64.const 120))
+(assert_return (invoke "fac" (i64.const 25)) (i64.const 7034535277573963776))
+
+(assert_return (invoke "even" (i32.const 0)) (i32.const 44))
+(assert_return (invoke "even" (i32.const 1)) (i32.const 99))
+(assert_return (invoke "even" (i32.const 100)) (i32.const 44))
+(assert_return (invoke "even" (i32.const 77)) (i32.const 99))
+(assert_return (invoke "even" (i32.const 100_000)) (i32.const 44))
+(assert_return (invoke "even" (i32.const 111_111)) (i32.const 99))
+(assert_return (invoke "odd" (i32.const 0)) (i32.const 99))
+(assert_return (invoke "odd" (i32.const 1)) (i32.const 44))
+(assert_return (invoke "odd" (i32.const 200)) (i32.const 99))
+(assert_return (invoke "odd" (i32.const 77)) (i32.const 44))
+(assert_return (invoke "odd" (i32.const 200_002)) (i32.const 99))
+(assert_return (invoke "odd" (i32.const 300_003)) (i32.const 44))
+
+
+;; Invalid syntax
+
+(assert_malformed
+  (module quote
+    "(type $sig (func (param i32) (result i32)))"
+    "(table 0 anyfunc)"
+    "(func (result i32)"
+    "  (return_call_indirect (type $sig) (result i32) (param i32)"
+    "    (i32.const 0) (i32.const 0)"
+    "  )"
+    ")"
+  )
+  "unexpected token"
+)
+(assert_malformed
+  (module quote
+    "(type $sig (func (param i32) (result i32)))"
+    "(table 0 anyfunc)"
+    "(func (result i32)"
+    "  (return_call_indirect (param i32) (type $sig) (result i32)"
+    "    (i32.const 0) (i32.const 0)"
+    "  )"
+    ")"
+  )
+  "unexpected token"
+)
+(assert_malformed
+  (module quote
+    "(type $sig (func (param i32) (result i32)))"
+    "(table 0 anyfunc)"
+    "(func (result i32)"
+    "  (return_call_indirect (param i32) (result i32) (type $sig)"
+    "    (i32.const 0) (i32.const 0)"
+    "  )"
+    ")"
+  )
+  "unexpected token"
+)
+(assert_malformed
+  (module quote
+    "(type $sig (func (param i32) (result i32)))"
+    "(table 0 anyfunc)"
+    "(func (result i32)"
+    "  (return_call_indirect (result i32) (type $sig) (param i32)"
+    "    (i32.const 0) (i32.const 0)"
+    "  )"
+    ")"
+  )
+  "unexpected token"
+)
+(assert_malformed
+  (module quote
+    "(type $sig (func (param i32) (result i32)))"
+    "(table 0 anyfunc)"
+    "(func (result i32)"
+    "  (return_call_indirect (result i32) (param i32) (type $sig)"
+    "    (i32.const 0) (i32.const 0)"
+    "  )"
+    ")"
+  )
+  "unexpected token"
+)
+(assert_malformed
+  (module quote
+    "(table 0 anyfunc)"
+    "(func (result i32)"
+    "  (return_call_indirect (result i32) (param i32)"
+    "    (i32.const 0) (i32.const 0)"
+    "  )"
+    ")"
+  )
+  "unexpected token"
+)
+
+(assert_malformed
+  (module quote
+    "(table 0 anyfunc)"
+    "(func (return_call_indirect (param $x i32) (i32.const 0) (i32.const 0)))"
+  )
+  "unexpected token"
+)
+(assert_malformed
+  (module quote
+    "(type $sig (func))"
+    "(table 0 anyfunc)"
+    "(func (result i32)"
+    "  (return_call_indirect (type $sig) (result i32) (i32.const 0))"
+    ")"
+  )
+  "inline function type"
+)
+(assert_malformed
+  (module quote
+    "(type $sig (func (param i32) (result i32)))"
+    "(table 0 anyfunc)"
+    "(func (result i32)"
+    "  (return_call_indirect (type $sig) (result i32) (i32.const 0))"
+    ")"
+  )
+  "inline function type"
+)
+(assert_malformed
+  (module quote
+    "(type $sig (func (param i32) (result i32)))"
+    "(table 0 anyfunc)"
+    "(func"
+    "  (return_call_indirect (type $sig) (param i32)"
+    "    (i32.const 0) (i32.const 0)"
+    "  )"
+    ")"
+  )
+  "inline function type"
+)
+(assert_malformed
+  (module quote
+    "(type $sig (func (param i32 i32) (result i32)))"
+    "(table 0 anyfunc)"
+    "(func (result i32)"
+    "  (return_call_indirect (type $sig) (param i32) (result i32)"
+    "    (i32.const 0) (i32.const 0)"
+    "  )"
+    ")"
+  )
+  "inline function type"
+)
+
+;; Invalid typing
+
+(assert_invalid
+  (module
+    (type (func))
+    (func $no-table (return_call_indirect (type 0) (i32.const 0)))
+  )
+  "unknown table"
+)
+
+(assert_invalid
+  (module
+    (type (func))
+    (table 0 anyfunc)
+    (func $type-void-vs-num (i32.eqz (return_call_indirect (type 0) (i32.const 0))))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type (func (result i64)))
+    (table 0 anyfunc)
+    (func $type-num-vs-num (i32.eqz (return_call_indirect (type 0) (i32.const 0))))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type (func (param i32)))
+    (table 0 anyfunc)
+    (func $arity-0-vs-1 (return_call_indirect (type 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type (func (param f64 i32)))
+    (table 0 anyfunc)
+    (func $arity-0-vs-2 (return_call_indirect (type 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(module
+  (type (func))
+  (table 0 anyfunc)
+  (func $arity-1-vs-0 (return_call_indirect (type 0) (i32.const 1) (i32.const 0)))
+)
+
+(module
+  (type (func))
+  (table 0 anyfunc)
+  (func $arity-2-vs-0
+    (return_call_indirect (type 0) (f64.const 2) (i32.const 1) (i32.const 0))
+  )
+)
+
+(assert_invalid
+  (module
+    (type (func (param i32)))
+    (table 0 anyfunc)
+    (func $type-func-void-vs-i32 (return_call_indirect (type 0) (i32.const 1) (nop)))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type (func (param i32)))
+    (table 0 anyfunc)
+    (func $type-func-num-vs-i32 (return_call_indirect (type 0) (i32.const 0) (i64.const 1)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type (func (param i32 i32)))
+    (table 0 anyfunc)
+    (func $type-first-void-vs-num
+      (return_call_indirect (type 0) (nop) (i32.const 1) (i32.const 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type (func (param i32 i32)))
+    (table 0 anyfunc)
+    (func $type-second-void-vs-num
+      (return_call_indirect (type 0) (i32.const 1) (nop) (i32.const 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type (func (param i32 f64)))
+    (table 0 anyfunc)
+    (func $type-first-num-vs-num
+      (return_call_indirect (type 0) (f64.const 1) (i32.const 1) (i32.const 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type (func (param f64 i32)))
+    (table 0 anyfunc)
+    (func $type-second-num-vs-num
+      (return_call_indirect (type 0) (i32.const 1) (f64.const 1) (i32.const 0))
+    )
+  )
+  "type mismatch"
+)
+
+
+;; Unbound type
+
+(assert_invalid
+  (module
+    (table 0 anyfunc)
+    (func $unbound-type (return_call_indirect (type 1) (i32.const 0)))
+  )
+  "unknown type"
+)
+(assert_invalid
+  (module
+    (table 0 anyfunc)
+    (func $large-type (return_call_indirect (type 1012321300) (i32.const 0)))
+  )
+  "unknown type"
+)
+
+
+;; Unbound function in table
+
+(assert_invalid
+  (module (table anyfunc (elem 0 0)))
+  "unknown function 0"
+)


### PR DESCRIPTION
This PR specs, implements, and tests a basic proposal for tail calls:

* It adds instructions `return_call` and `return_call_indirect`.
* Spec for validation, execution, binary, text format
* Implementation in the interpreter
* Tests for both instructions

The PR does not yet introduce any typing distinction for functions that are tail-callers or callees, the details of which still need to be worked out.

Rendered spec is at https://webassembly.github.io/tail-call/core