### PR TITLE
Describe correct tail call behavior across modules

### DIFF
--- a/proposals/tail-call/Overview.md
+++ b/proposals/tail-call/Overview.md
@@ -46,6 +46,8 @@ This can be applied to any form of call, that is:
 
 * Tail calls to host functions cannot guarantee tail behaviour (outside the scope of the spec)
 
+* Tail calls across WebAssembly module boundaries *do* guarantee tail behavior
+
 
 ### Typing
 
@@ -141,8 +143,3 @@ Use the reserved opcodes after existing call instructions, i.e.:
 ### Text Format
 
 The text format is extended with two new instructions in the obvious manner.
-
-
-## Open Questions
-
-* Can tail calls across module boundaries guarantee tail behaviour?


### PR DESCRIPTION
Whether tail calls across module boundaries would guarantee tail call behavior was previously an open question, but @thibaudmichaud confirmed that they would guarantee tail call behavior in V8 in https://github.com/WebAssembly/tail-call/issues/15#issuecomment-994821853.

cc @lars-t-hansen, @rossberg, @thibaudmichaud